### PR TITLE
Use RFC2616 recommandation to reply 401 instead on 403 for auth_failed

### DIFF
--- a/nginx-ldap-auth-daemon.py
+++ b/nginx-ldap-auth-daemon.py
@@ -114,7 +114,9 @@ class AuthHandler(BaseHTTPRequestHandler):
             msg += ', login="%s"' % ctx['user']
 
         self.log_error(msg)
-        self.send_response(403)
+        self.send_response(401)
+        self.send_header('WWW-Authenticate', 'Basic realm=' + ctx['realm'])
+        self.send_header('Cache-Control', 'no-cache')
         self.end_headers()
 
     def get_params(self):


### PR DESCRIPTION
Cf https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html ,

401 is for: auth failed... please retry ;)
-----------
10.4.2 401 Unauthorized
 The request requires user authentication. The response MUST include a WWW-Authenticate header field (section 14.47) containing a challenge applicable to the requested resource. The client MAY repeat the request with a suitable Authorization header field (section 14.8). If the request already included Authorization credentials, then the 401 response indicates that authorization has been refused for those credentials. If the 401 response contains the same challenge as the prior response, and the user agent has already attempted authentication at least once, then the user SHOULD be presented the entity that was given in the response, since that entity might include relevant diagnostic information. HTTP access authentication is explained in "HTTP Authentication: Basic and Digest Access Authentication" [43].



403 is for: more or less auth shouldn't be repeated
-----------
10.4.4 403 Forbidden
 The server understood the request, but is refusing to fulfill it. Authorization will not help and the request SHOULD NOT be repeated. If the request method was not HEAD and the server wishes to make public why the request has not been fulfilled, it SHOULD describe the reason for the refusal in the entity. If the server does not wish to make this information available to the client, the status code 404 (Not Found) can be used instead.

Regards,
Pascal