### PR TITLE
Quoted-string Basic realm ctx according to rfc7235

### DIFF
--- a/nginx-ldap-auth-daemon.py
+++ b/nginx-ldap-auth-daemon.py
@@ -61,7 +61,7 @@ class AuthHandler(BaseHTTPRequestHandler):
         if auth_header is None or not auth_header.lower().startswith('basic '):
 
             self.send_response(401)
-            self.send_header('WWW-Authenticate', 'Basic realm=' + ctx['realm'])
+            self.send_header('WWW-Authenticate', 'Basic realm="' + ctx['realm'] + '"')
             self.send_header('Cache-Control', 'no-cache')
             self.end_headers()
 
@@ -115,7 +115,7 @@ class AuthHandler(BaseHTTPRequestHandler):
 
         self.log_error(msg)
         self.send_response(401)
-        self.send_header('WWW-Authenticate', 'Basic realm=' + ctx['realm'])
+        self.send_header('WWW-Authenticate', 'Basic realm="' + ctx['realm'] + '"')
         self.send_header('Cache-Control', 'no-cache')
         self.end_headers()
 


### PR DESCRIPTION
Hi,

I faced some problems with 401 message and an Android client.

It yelded because in the WWW-Authenticate header the
Basic ream=<ctx>
wasn't surrouned by ""

In the https://tools.ietf.org/html/rfc7235 it is written that 
 - Authentication parameters are name=value pairs
 - and "auth-param     = token BWS "=" BWS ( token / quoted-string )"
 - and "_For historical reasons, a sender MUST only generate the quoted-string
   syntax.  Recipients might have to support both token and
   quoted-string syntax for maximum interoperability with existing
   clients that have been accepting both notations for a long time._"

After my modification, the Android worked again (and iOs and PC clients faicing the 401 still worked ;) )

BR,
Arfy