### PR TITLE
Fixed logging and typo for bind DN argument

### DIFF
--- a/nginx-ldap-auth-daemon.py
+++ b/nginx-ldap-auth-daemon.py
@@ -1,6 +1,6 @@
 #!/bin/sh
-''''which python2 >/dev/null && exec python2 "$0" "$@" # '''
-''''which python  >/dev/null && exec python  "$0" "$@" # '''
+''''which python2 >/dev/null && exec python2 -u "$0" "$@" &>>$LOG # '''
+''''which python  >/dev/null && exec python  -u "$0" "$@" &>>$LOG # '''
 
 # Copyright (C) 2014-2015 Nginx, Inc.
 

--- a/nginx-ldap-auth.default
+++ b/nginx-ldap-auth.default
@@ -4,7 +4,7 @@
 #
 #URL="--url ldap://example.com:389"
 #BASE="-b dc=nodomain"
-#BIND_DN="-d cn=admin,dc=nodomain"
+#BIND_DN="-D cn=admin,dc=nodomain"
 #BIND_PASS="-w secret"
 #COOKIE="-c nginxauth"
 #FILTER="-f (cn=%(username)s)"

--- a/nginx-ldap-auth.logrotate
+++ b/nginx-ldap-auth.logrotate
@@ -1,0 +1,8 @@
+/var/log/nginx-ldap-auth/daemon.log {
+	delaycompress
+	create 0644 nginx-ldap-auth nginx-ldap-auth
+	su nginx-ldap-auth nginx-ldap-auth
+	postrotate
+		/usr/bin/systemctl restart nginx-ldap-auth
+	endscript
+}

--- a/rpm/nginx-ldap-auth.spec
+++ b/rpm/nginx-ldap-auth.spec
@@ -12,6 +12,7 @@ BuildRequires:	systemd
 Requires:	systemd
 Requires:	python-ldap
 Requires:	python-argparse
+Requires:	logrotate
 
 %description
 Reference implementation of method for authenticating users on behalf of
@@ -28,10 +29,12 @@ mkdir -p %buildroot%_unitdir
 install -m644 %name.service %buildroot%_unitdir/
 install -d -m755 %buildroot/etc/default
 install -m644 %name.default %buildroot/etc/default/%name
+install -m644 %name.logrotate %buildroot%_sysconfdir/logrotate.d/%name
 
 %files
 %doc README.md nginx-ldap-auth.conf backend-sample-app.py LICENSE
 /etc/default/%name
+%_sysconfdir/logrotate.d/%name
 %_bindir/nginx-ldap-auth-daemon
 %_unitdir/%name.service
 


### PR DESCRIPTION
Sidenote: Hrm, other pushes ended up in this PR - I guess I should have used multiple branches to get separate PRs?

481b02a: nginx-ldap-auth-daemon.py expects "-D" instead of "-d" for the bind DN argument.
f946708: systemd calls the script as a bash script which execs and eats stdout. Catch stdout and stderr here.
d66d4a0: Install a logrotate config