### PR TITLE
Support custom CA Certificate for LDAPS

### DIFF
--- a/nginx-ldap-auth-daemon.py
+++ b/nginx-ldap-auth-daemon.py
@@ -151,6 +151,7 @@ class LDAPAuthHandler(AuthHandler):
              'template': ('X-Ldap-Template', '(cn=%(username)s)'),
              'binddn': ('X-Ldap-BindDN', ''),
              'bindpasswd': ('X-Ldap-BindPass', ''),
+             'cacertfile': ('X-Ldap-CACertFile', ''),
              'cookiename': ('X-CookieName', '')
         }
 
@@ -188,6 +189,10 @@ class LDAPAuthHandler(AuthHandler):
             if not ctx['basedn']:
                 self.log_message('LDAP baseDN is not set!')
                 return 
+
+            if ctx['cacertfile']:
+                self.log_message('Setting CA Certificate to: %s' % ctx['cacertfile'])
+                ldap.set_option(ldap.OPT_X_TLS_CACERTFILE, ctx['cacertfile'])
 
             ctx['action'] = 'initializing LDAP connection'
             ldap_obj = ldap.initialize(ctx['url']);
@@ -261,6 +266,8 @@ if __name__ == '__main__':
         help="LDAP bind DN (Default: anonymous)")
     group.add_argument('-w', metavar="passwd", dest="bindpw", default='',
         help="LDAP password for the bind DN (Default: unset)")
+    group.add_argument('-C', metavar="file", dest="cacertfile", default='',
+        help="LDAPS CA Certificate File (Default: unset)")
     group.add_argument('-f', '--filter', metavar='filter', 
         default='(cn=%(username)s)', 
         help="LDAP filter (Default: cn=%%(username)s)")
@@ -281,6 +288,7 @@ if __name__ == '__main__':
              'template': ('X-Ldap-Template', args.filter),
              'binddn': ('X-Ldap-BindDN', args.binddn),
              'bindpasswd': ('X-Ldap-BindPass', args.bindpw),
+             'cacertfile': ('X-Ldap-CACertFile', args.cacertfile),
              'cookiename': ('X-CookieName', args.cookie)
     }
     LDAPAuthHandler.set_params(auth_params)

--- a/nginx-ldap-auth.conf
+++ b/nginx-ldap-auth.conf
@@ -64,6 +64,7 @@ http {
             #    basedn         X-Ldap-BaseDN
             #    binddn         X-Ldap-BindDN
             #    bindpasswd     X-Ldap-BindPass
+            #    cacertfile     X-Ldap-CACertFile
             #    cookiename     X-CookieName
             #    realm          X-Ldap-Realm
             #    template       X-Ldap-Template
@@ -83,6 +84,10 @@ http {
 
             # (Required) Set the Bind password, by replacing 'secret'.
             proxy_set_header X-Ldap-BindPass "secret";
+
+            # (Optional) Path to a custom LDAPS CA certificate, only needed if
+            # the system ca bundle doesn't contain the custom CA Root certificate.
+            #proxy_set_header X-Ldap-CACertFile "/etc/pki/tls/certs/custom-ca-chain.pem";
 
             # (Required) The following directives set the cookie name and pass
             # it, respectively. They are required for cookie-based


### PR DESCRIPTION
Our organisation has its own Certification Authority that issues all the internal certificates, including the LDAPS certificate. This patch adds support for setting a custom CA chain path through a new proxy header X-Ldap-CACertFile.