### PR TITLE
Exit on SIGTERM for Kubernetes, print startup message

### DIFF
--- a/nginx-ldap-auth-daemon.py
+++ b/nginx-ldap-auth-daemon.py
@@ -239,6 +239,7 @@ def exit_handler(signal, frame):
             ex, value, trace = sys.exc_info()
             sys.stderr.write('Failed to remove socket "%s": %s\n' %
                              (Listen, str(value)))
+            sys.stderr.flush()
     sys.exit(0)
 
 if __name__ == '__main__':
@@ -286,4 +287,8 @@ if __name__ == '__main__':
     LDAPAuthHandler.set_params(auth_params)
     server = AuthHTTPServer(Listen, LDAPAuthHandler)
     signal.signal(signal.SIGINT, exit_handler)
+    signal.signal(signal.SIGTERM, exit_handler)
+
+    sys.stdout.write("Start listening on %s:%d...\n" % Listen)
+    sys.stdout.flush()
     server.serve_forever()


### PR DESCRIPTION
SIGINT is nice for interactive sessions and daemons but for Docker and especially Kubernetes a graceful exit on SIGTERM is required otherwise the shutdown is delayed by 30 seconds until the container is killed.