### PR TITLE
Fix a flaky shebang handling issue

### DIFF
--- a/nginx-ldap-auth-daemon.py
+++ b/nginx-ldap-auth-daemon.py
@@ -1,8 +1,7 @@
-#!/bin/sh
-''''which python2 >/dev/null && exec python2 -u "$0" "$@" &>>$LOG # '''
-''''which python  >/dev/null && exec python  -u "$0" "$@" &>>$LOG # '''
-
+#!/usr/bin/env python2
+#
 # Copyright (C) 2014-2015 Nginx, Inc.
+#
 
 import sys, os, signal, base64, ldap, Cookie, argparse
 from BaseHTTPServer import HTTPServer, BaseHTTPRequestHandler


### PR DESCRIPTION
Running nginx-ldap-auth daemon as-is yields the following results:
```
12:12 kegeruneku@arkhangelsk ~/repositories/other/nginx-ldap-auth % ./nginx-ldap-auth-daemon.py                
./nginx-ldap-auth-daemon.py: 2: ./nginx-ldap-auth-daemon.py: cannot create : Directory nonexistent
./nginx-ldap-auth-daemon.py: 3: ./nginx-ldap-auth-daemon.py: cannot create : Directory nonexistent
Traceback (most recent call last):
  File "./nginx-ldap-auth-daemon.py", line 287, in <module>
    server = AuthHTTPServer(Listen, LDAPAuthHandler)
  File "/usr/lib/python2.7/SocketServer.py", line 417, in __init__
    self.server_bind()
  File "/usr/lib/python2.7/BaseHTTPServer.py", line 108, in server_bind
    SocketServer.TCPServer.server_bind(self)
  File "/usr/lib/python2.7/SocketServer.py", line 431, in server_bind
    self.socket.bind(self.server_address)
  File "/usr/lib/python2.7/socket.py", line 228, in meth
    return getattr(self._sock,name)(*args)
socket.error: [Errno 98] Address already in use
```
I think it is a better idea to use env to select the python version to use, to prevent issues like this.

Moreover, as this project is advertised to support python 2 only, https://www.python.org/dev/peps/pep-0394/ recommends specifying 'python2' as interpreter