### PR TITLE
Python3compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:2-alpine
+ARG PYTHON_VERSION=2
+FROM python:${PYTHON_VERSION}-alpine
 
 COPY nginx-ldap-auth-daemon.py /usr/src/app/
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ To install and configure the reference implementation, perform the following ste
 
 1. On the host where the ldap-auth daemon is to run, install the following additional software. We recommend using the versions that are distributed with the operating system, instead of downloading the software from an open source repository.
 
-    - Python version 2 and 3 are supported.
+    - Python versions 2 and 3 are supported.
     - The Python LDAP module, **python-ldap** (created by the [python-ldap.org](http://www.python-ldap.org) open source project).
 
 1. Copy the following files from your repository clone to the indicated hosts:

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ To install and configure the reference implementation, perform the following ste
 
 1. On the host where the ldap-auth daemon is to run, install the following additional software. We recommend using the versions that are distributed with the operating system, instead of downloading the software from an open source repository.
 
-    - Python version 2. Version 3 is not supported.
+    - Python version 2 and 3 are supported.
     - The Python LDAP module, **python-ldap** (created by the [python-ldap.org](http://www.python-ldap.org) open source project).
 
 1. Copy the following files from your repository clone to the indicated hosts:
@@ -43,6 +43,10 @@ To install and configure the reference implementation, perform the following ste
       ```
       docker build -t nginx-ldap-auth-daemon .
       docker run nginx-ldap-auth-daemon
+      ```
+      If you desire to use a container with Python3, you can supply an appropriate build argument:
+      ```
+      docker build -t nginx-ldap-auth-daemon --build-arg PYTHON_VERSION=3 .
       ```
       
     - **nginx-ldap-auth-daemon-ctl.sh** – Sample shell script for starting and stopping the daemon. Install on the same host as the ldap-auth daemon.

--- a/backend-sample-app.py
+++ b/backend-sample-app.py
@@ -1,5 +1,4 @@
 #!/bin/sh
-''''which python2 >/dev/null && exec python2 "$0" "$@" # '''
 ''''which python  >/dev/null && exec python  "$0" "$@" # '''
 
 # Copyright (C) 2014-2015 Nginx, Inc.

--- a/backend-sample-app.py
+++ b/backend-sample-app.py
@@ -8,13 +8,29 @@
 # 1) accepts GET  requests on /login and responds with a login form
 # 2) accepts POST requests on /login, sets a cookie, and responds with redirect
 
-import sys, os, signal, base64, Cookie, cgi, urlparse
-from BaseHTTPServer import HTTPServer, BaseHTTPRequestHandler
+import sys, os, signal, base64, cgi
+if sys.version_info.major == 2:
+    from urlparse import urlparse
+    from Cookie import BaseCookie
+    from BaseHTTPServer import HTTPServer, BaseHTTPRequestHandler
+elif sys.version_info.major == 3:
+    from urllib.parse import urlparse
+    from http.cookies import BaseCookie
+    from http.server import HTTPServer, BaseHTTPRequestHandler
 
 Listen = ('localhost', 9000)
 
 import threading
-from SocketServer import ThreadingMixIn
+if sys.version_info.major == 2:
+    from SocketServer import ThreadingMixIn
+elif sys.version_info.major == 3:
+    from socketserver import ThreadingMixIn
+
+
+def ensure_bytes(data):
+    return data if sys.version_info.major == 2 else data.encode("utf-8")
+
+
 class AuthHTTPServer(ThreadingMixIn, HTTPServer):
     pass
 
@@ -22,14 +38,14 @@ class AppHandler(BaseHTTPRequestHandler):
 
     def do_GET(self):
 
-        url = urlparse.urlparse(self.path)
+        url = urlparse(self.path)
 
         if url.path.startswith("/login"):
             return self.auth_form()
 
         self.send_response(200)
         self.end_headers()
-        self.wfile.write('Hello, world! Requested URL: ' + self.path + '\n')
+        self.wfile.write(ensure_bytes('Hello, world! Requested URL: ' + self.path + '\n'))
 
 
     # send login form html
@@ -69,7 +85,7 @@ class AppHandler(BaseHTTPRequestHandler):
 
         self.send_response(200)
         self.end_headers()
-        self.wfile.write(html.replace('TARGET', target))
+        self.wfile.write(ensure_bytes(html.replace('TARGET', target)))
 
 
     # processes posted form and sets the cookie with login/password
@@ -102,8 +118,8 @@ class AppHandler(BaseHTTPRequestHandler):
             # and share a key with auth daemon that extracts this information
             #
             # WARNING WARNING WARNING
-            enc = base64.b64encode(user + ':' + passwd)
-            self.send_header('Set-Cookie', 'nginxauth=' + enc + '; httponly')
+            enc = base64.b64encode(ensure_bytes(user + ':' + passwd))
+            self.send_header('Set-Cookie', b'nginxauth=' + enc + b'; httponly')
 
             self.send_header('Location', target)
             self.end_headers()

--- a/nginx-ldap-auth-daemon.py
+++ b/nginx-ldap-auth-daemon.py
@@ -4,8 +4,15 @@
 
 # Copyright (C) 2014-2015 Nginx, Inc.
 
-import sys, os, signal, base64, ldap, Cookie, argparse
-from BaseHTTPServer import HTTPServer, BaseHTTPRequestHandler
+import sys, os, signal, base64, ldap, argparse
+if sys.version_info.major == 2:
+    from Cookie import BaseCookie
+    from BaseHTTPServer import HTTPServer, BaseHTTPRequestHandler
+elif sys.version_info.major == 3:
+    from http.cookies import BaseCookie
+    from http.server import HTTPServer, BaseHTTPRequestHandler
+
+if not hasattr(__builtins__, "basestring"): basestring = (str, bytes)
 
 #Listen = ('localhost', 8888)
 #Listen = "/tmp/auth.sock"    # Also uncomment lines in 'Requests are
@@ -16,7 +23,11 @@ from BaseHTTPServer import HTTPServer, BaseHTTPRequestHandler
 # -----------------------------------------------------------------------------
 # Requests are processed in separate thread
 import threading
-from SocketServer import ThreadingMixIn
+if sys.version_info.major == 2:
+    from SocketServer import ThreadingMixIn
+elif sys.version_info.major == 3:
+    from socketserver import ThreadingMixIn
+
 class AuthHTTPServer(ThreadingMixIn, HTTPServer):
     pass
 # -----------------------------------------------------------------------------
@@ -71,6 +82,7 @@ class AuthHandler(BaseHTTPRequestHandler):
 
         try:
             auth_decoded = base64.b64decode(auth_header[6:])
+            if sys.version_info.major == 3: auth_decoded = auth_decoded.decode("utf-8")
             user, passwd = auth_decoded.split(':', 1)
 
         except:
@@ -86,7 +98,7 @@ class AuthHandler(BaseHTTPRequestHandler):
     def get_cookie(self, name):
         cookies = self.headers.get('Cookie')
         if cookies:
-            authcookie = Cookie.BaseCookie(cookies).get(name)
+            authcookie = BaseCookie(cookies).get(name)
             if authcookie:
                 return authcookie.value
             else:

--- a/nginx-ldap-auth-daemon.py
+++ b/nginx-ldap-auth-daemon.py
@@ -1,6 +1,5 @@
 #!/bin/sh
 ''''[ -z $LOG ] && export LOG=/dev/stdout # '''
-''''which python2 >/dev/null && exec python2 -u "$0" "$@" >> $LOG 2>&1 # '''
 ''''which python  >/dev/null && exec python  -u "$0" "$@" >> $LOG 2>&1 # '''
 
 # Copyright (C) 2014-2015 Nginx, Inc.


### PR DESCRIPTION
This PR introduces compatibility with Python3 while maintaining backward compatibility.
For the time being, Dockerfile assumes Python2 as the default version.
It can be changed later, ideally before 2020.

Directly inspired by PR #66 by @goochjj
