### PR TITLE
Support CA cert file by setting an env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ To install and configure the reference implementation, perform the following ste
       ```
       docker build -t nginx-ldap-auth-daemon --build-arg PYTHON_VERSION=3 .
       ```
+      If you want to use a CA certification file for validating the LDAP authentication server when using TLS, you can set the `LDAP_CA_CERT` environment variable in the environment running the authentication daemon. With the Docker container, you can do:
+      ```
+      docker run -e LDAP_CA_CERT='/path/to/cacert/file' nginx-ldap-auth-daemon
+      ```
 
     - **nginx-ldap-auth-daemon-ctl.sh** – Sample shell script for starting and stopping the daemon. Install on the same host as the ldap-auth daemon.
 

--- a/nginx-ldap-auth-daemon.py
+++ b/nginx-ldap-auth-daemon.py
@@ -218,6 +218,10 @@ class LDAPAuthHandler(AuthHandler):
             # Establish a STARTTLS connection if required by the
             # headers.
             if ctx['starttls'] == 'true':
+                cacert_file = os.getenv("LDAP_CA_CERT")
+                if cacert_file:
+                    ldap_obj.set_option(ldap.OPT_X_TLS_CACERTFILE, cacert_file)
+                    ldap_obj.set_option(ldap.OPT_X_TLS_NEWCTX, 0)
                 ldap_obj.start_tls_s()
 
             # See https://www.python-ldap.org/en/latest/faq.html


### PR DESCRIPTION
Add the option to use a CA cert file by setting the environment variable  with the path to the CA cert file.
Reference documentation here : https://www.python-ldap.org/en/python-ldap-3.3.0/reference/ldap.html#tls-options