### PR TITLE
Call sys.stdout.flush() just after calling sys.stdout.write() on AuthHandler.log_message()

### DIFF
--- a/nginx-ldap-auth-daemon.py
+++ b/nginx-ldap-auth-daemon.py
@@ -147,6 +147,7 @@ class AuthHandler(BaseHTTPRequestHandler):
 
         sys.stdout.write("%s - %s [%s] %s\n" % (addr, user,
                          self.log_date_time_string(), format % args))
+        sys.stdout.flush()
 
     def log_error(self, format, *args):
         self.log_message(format, *args)


### PR DESCRIPTION
Flush log messages written into stdout by calling `sys.stdout.flush()`.

It seems to be missed only on `log_message()` in class `AuthHandler`.

This fixing is needed to get log message on Docker environment (typically `docker logs`).